### PR TITLE
Setup provide idempotent

### DIFF
--- a/src/setup_provide
+++ b/src/setup_provide
@@ -80,10 +80,23 @@ def add_exception(EXCEPTIONS):
     """
         adds exception for mkorma01 account to allow for testing
     """
-    with EXCEPTIONS.open("a") as f:
-        f.write(
-            "login=mkorma01 status=on duedate=12/25 duetime=11:59pm submissions=10000 "
-        )
+    TESTACCOUNT="mkorma01"
+    foundConfig, region = getLastWhere(
+        EXCEPTIONS,
+        re.compile(r'\blogin=%s\b' % TESTACCOUNT).search
+    )
+    newConfig = {
+        **foundConfig,
+        **{
+            "login": TESTACCOUNT,
+            "status": "on",
+            "duedate": "12/25",
+            "duetime": "11:59pm",
+            "submissions": "10000"
+        }
+    }
+
+    addToConfFile(newConfig, EXCEPTIONS, *region)
 
 
 def create_testset(assign, files, courseId, assignId):


### PR DESCRIPTION
This pull request makes setup_provide more idempotent

Specifically :

* Rerunning setup-provide will merge an existing testset with the new one
* Rerunning setup-provide will update an existing exception for the test account, instead of making many



Closes #12 